### PR TITLE
Fix: adding l2 engine kind param in .env for faster sync

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -11,7 +11,10 @@ OP_SEQUENCER_HTTP=https://mainnet-sequencer.base.org
 
 # [required] replace with your preferred L1 (Ethereum, not Base) node RPC URL:
 OP_NODE_L1_ETH_RPC=https://1rpc.io/eth
-OP_NODE_L2_ENGINE_KIND=reth
+
+# [optional] replace this with your preferred L2 engine kind (geth, reth, etc.)
+# For more info: https://docs.optimism.io/operators/node-operators/configuration/consensus-config#l2enginekind
+# OP_NODE_L2_ENGINE_KIND=reth 
 
 # [required] replace with your preferred L1 CL beacon endpoint:
 OP_NODE_L1_BEACON=https://your.mainnet.beacon.node/endpoint-here

--- a/.env.mainnet
+++ b/.env.mainnet
@@ -11,6 +11,7 @@ OP_SEQUENCER_HTTP=https://mainnet-sequencer.base.org
 
 # [required] replace with your preferred L1 (Ethereum, not Base) node RPC URL:
 OP_NODE_L1_ETH_RPC=https://1rpc.io/eth
+OP_NODE_L2_ENGINE_KIND=reth
 
 # [required] replace with your preferred L1 CL beacon endpoint:
 OP_NODE_L1_BEACON=https://your.mainnet.beacon.node/endpoint-here


### PR DESCRIPTION
This param fixes the slow sync which is being faced by a lot of people. This has been a missing piece of config, which enabled faster sync.
For more info: https://docs.optimism.io/builders/node-operators/configuration/consensus-config#l2enginekind