### PR TITLE
chore: simplified variable check condition

### DIFF
--- a/nethermind/nethermind-entrypoint
+++ b/nethermind/nethermind-entrypoint
@@ -25,7 +25,7 @@ fi
 mkdir -p "$NETHERMIND_DATA_DIR"
 
 # Write the JWT secret
-if [[ -z "${OP_NODE_L2_ENGINE_AUTH_RAW:-}" ]]; then
+if [[ -z "$OP_NODE_L2_ENGINE_AUTH_RAW" ]]; then
     echo "Expected OP_NODE_L2_ENGINE_AUTH_RAW to be set" 1>&2
     exit 1
 fi


### PR DESCRIPTION
Updated the condition checking the `OP_NODE_L2_ENGINE_AUTH_RAW` variable.
The original check was a bit more complex than necessary.
I've simplified it to a more concise version that still correctly performs the check.
