### PR TITLE
Update nodes version for pectra readiness

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.22 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.10.2
-ENV COMMIT=8bf7ff60f34a7c5082cec5c56bed1f76cc1893ad
+ENV VERSION=v1.11.0
+ENV COMMIT=70fa4491f45b3d5d493394da2a154e3f22b61a5a
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -24,8 +24,8 @@ RUN apt-get update && \
     build-essential
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101411.6
-ENV COMMIT=50b3422b9ac682a8fa503c4f409339a9bff69717
+ENV VERSION=v1.101500.0
+ENV COMMIT=9111c8f18ce514916105252f4530782e2ac2b598
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/nethermind/Dockerfile
+++ b/nethermind/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.22 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.10.2
-ENV COMMIT=8bf7ff60f34a7c5082cec5c56bed1f76cc1893ad
+ENV VERSION=v1.11.0
+ENV COMMIT=70fa4491f45b3d5d493394da2a154e3f22b61a5a
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.22 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.10.2
-ENV COMMIT=8bf7ff60f34a7c5082cec5c56bed1f76cc1893ad
+ENV VERSION=op-node/v1.11.0
+ENV COMMIT=70fa4491f45b3d5d493394da2a154e3f22b61a5a
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -24,8 +24,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.1.5
-ENV COMMIT=3212af2d85a54eb207661361ac9fe1d7de4b5b8e
+ENV VERSION=v1.2.0
+ENV COMMIT=1e965caf5fa176f244a31c0d2662ba1b590938db
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
op-node to v1.11.0
op-geth to v1.101500
op-reth to 1.2.0

OP: https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.11.0
Reth: https://github.com/paradigmxyz/reth/releases/tag/v1.2.0