### PR TITLE
Fix JWT secret file handling in Nethermind entrypoint

### DIFF
--- a/nethermind/nethermind-entrypoint
+++ b/nethermind/nethermind-entrypoint
@@ -23,13 +23,14 @@ fi
 
 # Create necessary directories
 mkdir -p "$NETHERMIND_DATA_DIR"
+mkdir -p "$(dirname "$JWT_SECRET_FILE")"
 
 # Write the JWT secret
 if [[ -z "$OP_NODE_L2_ENGINE_AUTH_RAW" ]]; then
     echo "Expected OP_NODE_L2_ENGINE_AUTH_RAW to be set" 1>&2
     exit 1
 fi
-echo "$OP_NODE_L2_ENGINE_AUTH_RAW" > "$OP_NODE_L2_ENGINE_AUTH"
+echo "$OP_NODE_L2_ENGINE_AUTH_RAW" > "$JWT_SECRET_FILE"
 
 # Additional arguments based on environment variables
 if [ "${OP_NETHERMIND_BOOTNODES+x}" = x ]; then
@@ -54,7 +55,7 @@ exec ./nethermind \
     --JsonRpc.Host=0.0.0.0 \
     --JsonRpc.WebSocketsPort="$WS_PORT" \
     --JsonRpc.Port="$RPC_PORT" \
-    --JsonRpc.JwtSecretFile="$OP_NODE_L2_ENGINE_AUTH" \
+    --JsonRpc.JwtSecretFile="$JWT_SECRET_FILE" \
     --JsonRpc.EngineHost=0.0.0.0 \
     --JsonRpc.EnginePort="$AUTHRPC_PORT" \
     --HealthChecks.Enabled=true \


### PR DESCRIPTION

- Add missing directory creation for JWT secret file
- Use consistent JWT_SECRET_FILE variable instead of undefined OP_NODE_L2_ENGINE_AUTH