### PR TITLE
Add web3 namespace to reth-entrypoint

### DIFF
--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -23,12 +23,12 @@ exec ./op-reth node \
   --ws.origins="*" \
   --ws.addr=0.0.0.0 \
   --ws.port="$WS_PORT" \
-  --ws.api=debug,eth,net,txpool \
+  --ws.api=web3,debug,eth,net,txpool \
   --http \
   --http.corsdomain="*" \
   --http.addr=0.0.0.0 \
   --http.port="$RPC_PORT" \
-  --http.api=debug,eth,net,txpool \
+  --http.api=web3,debug,eth,net,txpool \
   --authrpc.addr=0.0.0.0 \
   --authrpc.port="$AUTHRPC_PORT" \
   --authrpc.jwtsecret="$OP_NODE_L2_ENGINE_AUTH" \


### PR DESCRIPTION
The web3 namespace was not enabled by default in the `http.api` and `ws.api` options within the reth-entrypoint script. This caused compatibility issues with external services, such as Chainlink nodes, which rely on `web3_clientVersion` for health checks.

This commit adds `web3` to the exposed namespaces, ensuring compatibility with standard EVM JSON-RPC expectations.