### PR TITLE
docs: fix minor wording issue in security section

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ platform.
 The HackerOne platform allows us to have a centralized and single reporting
 source for us to deliver optimized SLA's and results. All reports submitted to
 the platform are triaged around the clock by our team of Coinbase engineers
-with domain knowledge, assuring the best quality of review.
+with domain knowledge, ensuring the best quality of review.
 
 For more information on reporting vulnerabilities and our HackerOne bug bounty
 program, view our [security program policies][7].


### PR DESCRIPTION
I updated the phrase "assuring the best quality of review" to "ensuring the best quality of review" for better clarity and accuracy. "Ensure" is more appropriate here, as it emphasizes guaranteeing the outcome of the review process.