### PR TITLE
Build arm64 multiplatform images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,10 +17,14 @@ env:
 
 jobs:
   geth:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [linux/amd64]
+        settings:
+          - arch: linux/amd64
+            runs-on: ubuntu-24.04
+          - arch: linux/arm64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -31,11 +35,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: ${{ matrix.arch }}
 
       - name: Extract metadata for the Docker image
         id: meta
@@ -49,21 +48,45 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push the Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: geth/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.NAMESPACE }}/${{ env.GETH_DEPRECATED_IMAGE_NAME }},${{ env.NAMESPACE }}/${{ env.GETH_IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.arch }}
+          platforms: ${{ matrix.settings.arch }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.settings.arch }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+  
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-geth-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
   reth:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
+        settings:
           - arch: linux/amd64
+            runs-on: ubuntu-24.04
             features: jemalloc,asm-keccak,optimism
+          - arch: linux/arm64
+            runs-on: ubuntu-24.04-arm
+            features: jemalloc,optimism
+    runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -86,21 +109,46 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push the Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: reth/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.NAMESPACE }}/${{ env.RETH_IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            FEATURES=${{ matrix.features }}
-          platforms: ${{ matrix.arch }}
+            FEATURES=${{ matrix.settings.features }}
+          platforms: ${{ matrix.settings.arch }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.settings.arch }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-reth-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   nethermind:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [linux/amd64]
+        settings:
+          - arch: linux/amd64
+            runs-on: ubuntu-24.04
+          - arch: linux/arm64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -111,11 +159,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: ${{ matrix.arch }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -128,11 +171,153 @@ jobs:
             ${{ env.NAMESPACE }}/${{ env.NETHERMIND_IMAGE_NAME }}
 
       - name: Build and push the Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: nethermind/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.NAMESPACE }}/${{ env.NETHERMIND_IMAGE_NAME }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.arch }}
+          platforms: ${{ matrix.settings.arch }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Prepare
+        run: |
+          platform=${{ matrix.settings.arch }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-nethermind-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+
+  merge-geth:
+    runs-on: ubuntu-latest
+    needs:
+      - geth
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-geth-*
+          merge-multiple: true
+
+      - name: Log into the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for the Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.NAMESPACE }}/${{ env.GETH_DEPRECATED_IMAGE_NAME }}
+            ${{ env.NAMESPACE }}/${{ env.GETH_IMAGE_NAME }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.NAMESPACE }}/${{ env.GETH_DEPRECATED_IMAGE_NAME }}@sha256:%s ' *)
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.NAMESPACE }}/${{ env.GETH_IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.NAMESPACE }}/${{ env.GETH_DEPRECATED_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.NAMESPACE }}/${{ env.GETH_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  merge-reth:
+    runs-on: ubuntu-latest
+    needs:
+      - reth
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-reth-*
+          merge-multiple: true
+
+      - name: Log into the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for the Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.NAMESPACE }}/${{ env.RETH_IMAGE_NAME }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.NAMESPACE }}/${{ env.RETH_IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.NAMESPACE }}/${{ env.RETH_IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+
+  merge-nethermind:
+    runs-on: ubuntu-latest
+    needs:
+      - nethermind
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-nethermind-*
+          merge-multiple: true
+
+      - name: Log into the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata for the Docker image
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.NAMESPACE }}/${{ env.NETHERMIND_IMAGE_NAME }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.NAMESPACE }}/${{ env.NETHERMIND_IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.NAMESPACE }}/${{ env.NETHERMIND_IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,20 +6,19 @@ on:
 
 jobs:
   geth:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [linux/amd64]
+        settings:
+          - arch: linux/amd64
+            runs-on: ubuntu-24.04
+          - arch: linux/arm64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: ${{ matrix.arch }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -30,15 +29,19 @@ jobs:
           context: .
           file: geth/Dockerfile
           push: false
-          platforms: ${{ matrix.arch }}
+          platforms: ${{ matrix.settings.arch }}
 
   reth:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
+        settings:
           - arch: linux/amd64
+            runs-on: ubuntu-24.04
             features: jemalloc,asm-keccak,optimism
+          - arch: linux/arm64
+            runs-on: ubuntu-24.04-arm
+            features: jemalloc,optimism
+    runs-on: ${{ matrix.settings.runs-on}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -53,14 +56,18 @@ jobs:
           file: reth/Dockerfile
           push: false
           build-args: |
-            FEATURES=${{ matrix.features }}
-          platforms: ${{ matrix.arch }}
+            FEATURES=${{ matrix.settings.features }}
+          platforms: ${{ matrix.settings.arch }}
 
   nethermind:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [linux/amd64]
+        settings:
+          - arch: linux/amd64
+            runs-on: ubuntu-24.04
+          - arch: linux/arm64
+            runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.settings.runs-on}}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -69,9 +76,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build the Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: nethermind/Dockerfile
           push: false
-          platforms: ${{ matrix.arch }}
+          platforms: ${{ matrix.settings.arch }}


### PR DESCRIPTION
Updates the action workflows to build images for amd64 and arm64, then create a multiplatform manifest image for them.

## Changes

The builds were using QEMU, but that seemed to OOM or [take 5+ hours to complete](https://github.com/dguenther/node/actions/runs/13889073913). This PR uses the Linux ARM runners that are [available in public preview](https://github.com/orgs/community/discussions/148648). The multiplatform build is based off [the Docker docs](https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners).

## Future Improvements

* Builds still take between ~26-40 mins to complete, up from ~20 mins with x64. If that's too slow, we could try [larger ARM runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#specifications-for-general-larger-runners) or optimizing the reth build.

* There's a lot of code duplication in the workflows -- it'd be nice to clean up, but I think it'd make this PR tough to review if it was done here.

## Testing
* ✅  Images are available on `ghcr.io/dguenther/node-geth:main`, etc. Tested and merged this on my fork (with the repo owner changed).
* ✅  Ran `node`, `node-geth`, `node-reth` on Base Sepolia for ~30 secs using supervisord
* ❌  `node-nethermind` errors with `spawnerr: command at '/app/execution-entrypoint' is not executable` under supervisord -- I reproduced that issue on `base/node-nethermind:main`, so not related to this change. lmk if you'd like additional testing here.