### PR TITLE
chore: update reth to 1.3.9

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -22,8 +22,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.3.7
-ENV COMMIT=ed7da87da4de340a437bf46f39a7e1397ac82065
+ENV VERSION=v1.3.9
+ENV COMMIT=00e5b6e01e3cf4c86cb3625f7aff52b81960d724
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### Description
Update reth to the latest version to pull in the Base Sepolia Isthmus activation timestamp. https://github.com/paradigmxyz/reth/releases/tag/v1.3.9