### PR TITLE
chore: bump reth to v1.3.11

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -22,8 +22,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.3.9
-ENV COMMIT=00e5b6e01e3cf4c86cb3625f7aff52b81960d724
+ENV VERSION=v1.3.11
+ENV COMMIT=e0e85aa10b98fa92d32c3e820c7ed2cee0b02931
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### Description
Update Reth to the latest version which contains a p2p fix for clients doing EL sync on Isthmus.

https://github.com/paradigmxyz/reth/releases/tag/v1.3.11