### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log into the Container registry
         uses: docker/login-action@v3
@@ -89,7 +89,7 @@ jobs:
     runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log into the Container registry
         uses: docker/login-action@v3
@@ -151,7 +151,7 @@ jobs:
     runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log into the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.settings.runs-on }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.settings.runs-on}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Docker Buildx
@@ -70,7 +70,7 @@ jobs:
     runs-on: ${{ matrix.settings.runs-on}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Docker Buildx


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected