### PR TITLE
feat: add additional port configuration options for disc/p2p

### DIFF
--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -9,6 +9,7 @@ AUTHRPC_PORT="${AUTHRPC_PORT:-8551}"
 METRICS_PORT="${METRICS_PORT:-6060}"
 HOST_IP="" # put your external IP address here and open port 30303 to improve peer connectivity
 P2P_PORT="${P2P_PORT:-30303}"
+DISCOVERY_PORT="${DISCOVERY_PORT:-30303}"
 ADDITIONAL_ARGS=""
 OP_GETH_GCMODE="${OP_GETH_GCMODE:-full}"
 OP_GETH_SYNCMODE="${OP_GETH_SYNCMODE:-full}"
@@ -80,6 +81,7 @@ exec ./geth \
     --rollup.sequencerhttp="$OP_GETH_SEQUENCER_HTTP" \
     --rollup.halt=major \
     --op-network="$OP_NODE_NETWORK" \
+    --discovery.port="$DISCOVERY_PORT" \
     --port="$P2P_PORT" \
     --rollup.disabletxpoolgossip=true \
     --cache="$GETH_CACHE" \

--- a/nethermind/nethermind-entrypoint
+++ b/nethermind/nethermind-entrypoint
@@ -11,7 +11,7 @@ WS_PORT="${WS_PORT:-8546}"
 AUTHRPC_PORT="${AUTHRPC_PORT:-8551}"
 METRICS_PORT="${METRICS_PORT:-6060}"
 DISCOVERY_PORT="${DISCOVERY_PORT:-30303}"
-
+P2P_PORT="${P2P_PORT:-30303}"
 JWT_SECRET_FILE=${JWT_SECRET_FILE:-/tmp/jwt/jwtsecret}
 ADDITIONAL_ARGS=""
 
@@ -60,4 +60,6 @@ exec ./nethermind \
     --HealthChecks.Enabled=true \
     --Metrics.Enabled=true \
     --Metrics.ExposePort="$METRICS_PORT" \
+    --Network.P2PPort="$P2P_PORT" \
+    --Network.DiscoveryPort="$DISCOVERY_PORT" \
     $ADDITIONAL_ARGS

--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -7,6 +7,8 @@ RPC_PORT="${RPC_PORT:-8545}"
 WS_PORT="${WS_PORT:-8546}"
 AUTHRPC_PORT="${AUTHRPC_PORT:-8551}"
 METRICS_PORT="${METRICS_PORT:-6060}"
+DISCOVERY_PORT="${DISCOVERY_PORT:-30303}"
+P2P_PORT="${P2P_PORT:-30303}"
 ADDITIONAL_ARGS=""
 NODE_TYPE="${NODE_TYPE:-vanilla}"
 
@@ -56,4 +58,6 @@ exec $BINARY node \
   --chain "$RETH_CHAIN" \
   --rollup.sequencer-http=$RETH_SEQUENCER_HTTP \
   --rollup.disable-tx-pool-gossip \
+  --discovery.port="$DISCOVERY_PORT" \
+  --port="$P2P_PORT" \
   $ADDITIONAL_ARGS


### PR DESCRIPTION
Adds additional options for running nodes to override the default discovery/p2p ports.

This is useful for running in a constrained environment (behind NAT) where other nodes such as L1 may be already be listening on port 30303 