### PR TITLE
Update op-node and Nethermind for Isthmus hard fork

### DIFF
--- a/nethermind/Dockerfile
+++ b/nethermind/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.22 AS op
+FROM golang:1.23 AS op
 
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.12.1
-ENV COMMIT=d3b8eadd80457c74d9c4251948ac11e8d14a9c9c
+ENV VERSION=v1.13.3
+ENV COMMIT=b1e7c63bb2ffea46771c302bcb05f72ba1a7bf61
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -13,7 +13,7 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
 RUN curl -sSfL 'https://just.systems/install.sh' | bash -s -- --to /usr/local/bin
 
 RUN cd op-node && \
-    make VERSION=$VERSION op-node
+    just VERSION=$VERSION op-node
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS build
 
@@ -23,8 +23,8 @@ ARG TARGETARCH
 WORKDIR /app
 
 ENV REPO=https://github.com/NethermindEth/nethermind.git
-ENV VERSION=1.31.0
-ENV COMMIT=a7337ba9e29a5e9384c7dfad72be6c7ab576d907
+ENV VERSION=1.31.11
+ENV COMMIT=2be1890ee4f21f921a471de058dcb57937bd9b90
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c $VERSION 
 RUN bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
- Updates op-node to 1.13.3 to support Isthmus hard fork.
- Updates Nethermind to 1.33.11 to support Isthmas hard fork + fix invalid blocks being rejected while syncing.

Also updates build dependencies that were required. 

Fixes #469 