### PR TITLE
Automate Node Upgrade Process: Update Dependencies

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -1,34 +1,27 @@
-FROM golang:1.22 AS op
+FROM golang:1.23 AS op
+
+RUN curl -sSfL 'https://just.systems/install.sh' | bash -s -- --to /usr/local/bin
 
 WORKDIR /app
 
-ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.13.2
-ENV COMMIT=c8b9f62736a7dad7e569719a84c406605f4472e6
-RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
-    git switch -c branch-$VERSION && \
-    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
+COPY versions.env /tmp/versions.env
 
-# Install 'just'
-RUN curl -sSfL 'https://just.systems/install.sh' | bash -s -- --to /usr/local/bin
+RUN . /tmp/versions.env && git clone $OP_NODE_REPO --branch $OP_NODE_TAG --single-branch . && \
+    git switch -c branch-$OP_NODE_TAG && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$OP_NODE_COMMIT" ]'
 
-RUN cd op-node && \
-    make VERSION=$VERSION op-node
+RUN . /tmp/versions.env && cd op-node && \
+    make VERSION=$OP_NODE_TAG op-node
 
 FROM golang:1.22 AS geth
 
 WORKDIR /app
 
-RUN apt-get update && \
-    apt-get install -y \
-    build-essential
+COPY versions.env /tmp/versions.env
 
-ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101503.4
-ENV COMMIT=2b9abb39077cb88f6e8a513f09a5ea2c2569dfed
-RUN git clone $REPO --branch $VERSION --single-branch . && \
-    git switch -c branch-$VERSION && \
-    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
+RUN . /tmp/versions.env && git clone $OP_GETH_REPO --branch $OP_GETH_TAG --single-branch . && \
+    git switch -c branch-$OP_GETH_TAG && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$OP_GETH_COMMIT" ]'
 
 RUN go run build/ci.go install -static ./cmd/geth
 

--- a/nethermind/Dockerfile
+++ b/nethermind/Dockerfile
@@ -1,19 +1,17 @@
 FROM golang:1.23 AS op
 
-WORKDIR /app
-
-ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.13.3
-ENV COMMIT=b1e7c63bb2ffea46771c302bcb05f72ba1a7bf61
-RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
-    git switch -c branch-$VERSION && \
-    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
-
-# Install 'just'
 RUN curl -sSfL 'https://just.systems/install.sh' | bash -s -- --to /usr/local/bin
 
-RUN cd op-node && \
-    just VERSION=$VERSION op-node
+WORKDIR /app
+
+COPY versions.env /tmp/versions.env
+
+RUN . /tmp/versions.env && git clone $OP_NODE_REPO --branch $OP_NODE_TAG --single-branch . && \
+    git switch -c branch-$OP_NODE_TAG && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$OP_NODE_COMMIT" ]'
+
+RUN . /tmp/versions.env && cd op-node && \
+    just VERSION=$OP_NODE_TAG op-node
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS build
 
@@ -22,12 +20,12 @@ ARG TARGETARCH
 
 WORKDIR /app
 
-ENV REPO=https://github.com/NethermindEth/nethermind.git
-ENV VERSION=1.31.11
-ENV COMMIT=2be1890ee4f21f921a471de058dcb57937bd9b90
-RUN git clone $REPO --branch $VERSION --single-branch . && \
-    git switch -c $VERSION 
-RUN bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
+COPY versions.env /tmp/versions.env
+
+RUN . /tmp/versions.env && git clone $NETHERMIND_REPO --branch $NETHERMIND_TAG --single-branch . && \
+    git switch -c $NETHERMIND_TAG && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$NETHERMIND_COMMIT" ]'
+    
 RUN TARGETARCH=${TARGETARCH#linux/} && \
     arch=$([ "$TARGETARCH" = "amd64" ] && echo "x64" || echo "$TARGETARCH") && \
     echo "Using architecture: $arch" && \

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -1,32 +1,29 @@
-FROM golang:1.22 AS op
+FROM golang:1.23 AS op
+
+RUN curl -sSfL 'https://just.systems/install.sh' | bash -s -- --to /usr/local/bin
 
 WORKDIR /app
 
-ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.13.2
-ENV COMMIT=c8b9f62736a7dad7e569719a84c406605f4472e6
-RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
-    git switch -c branch-$VERSION && \
-    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
+COPY versions.env /tmp/versions.env
 
-# Install 'just'
-RUN curl -sSfL 'https://just.systems/install.sh' | bash -s -- --to /usr/local/bin
+RUN . /tmp/versions.env && git clone $OP_NODE_REPO --branch $OP_NODE_TAG --single-branch . && \
+    git switch -c branch-$OP_NODE_TAG && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$OP_NODE_COMMIT" ]'
 
-RUN cd op-node && \
-    make VERSION=$VERSION op-node
+RUN . /tmp/versions.env && cd op-node && \
+    make VERSION=$OP_NODE_TAG op-node
 
 FROM rust:1.87 AS reth
 
 WORKDIR /app
 
+COPY versions.env /tmp/versions.env
+
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
-ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.4.3
-ENV COMMIT=fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5
-RUN git clone $REPO --branch $VERSION --single-branch . && \
-    git switch -c branch-$VERSION && \
-    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
+RUN . /tmp/versions.env && git clone $OP_RETH_REPO --branch $OP_RETH_TAG --single-branch . && \
+    git switch -c branch-$OP_RETH_TAG && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$OP_RETH_COMMIT" ]'
 
 RUN cargo build --bin op-reth --profile maxperf --manifest-path crates/optimism/bin/Cargo.toml
 
@@ -34,16 +31,15 @@ FROM rust:1.87 AS reth-base
 
 WORKDIR /app
 
+COPY versions.env /tmp/versions.env
+
 RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y git libclang-dev pkg-config curl build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-ENV REPO=https://github.com/base/node-reth.git
-ENV VERSION=v0.1.1
-ENV COMMIT=cb55e69e3d88f8272ccc523c6c352d00b4ce2bf1
-RUN git clone $REPO . && \
-    git checkout tags/$VERSION && \
-    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]' || (echo "Commit hash verification failed" && exit 1)
+RUN . /tmp/versions.env && git clone $BASE_RETH_NODE_REPO . && \
+    git checkout tags/$BASE_RETH_NODE_TAG && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$BASE_RETH_NODE_COMMIT" ]' || (echo "Commit hash verification failed" && exit 1)
 
 RUN cargo build --bin base-reth-node --release
 

--- a/versions.env
+++ b/versions.env
@@ -1,0 +1,20 @@
+export OP_NODE_TAG=op-node/v1.13.3
+export OP_NODE_COMMIT=b1e7c63bb2ffea46771c302bcb05f72ba1a7bf61
+export OP_NODE_REPO=https://github.com/ethereum-optimism/optimism.git
+
+export OP_GETH_TAG=v1.101503.4
+export OP_GETH_COMMIT=2b9abb39077cb88f6e8a513f09a5ea2c2569dfed
+export OP_GETH_REPO=https://github.com/ethereum-optimism/op-geth.git
+
+export OP_RETH_TAG=v1.4.3
+export OP_RETH_COMMIT=fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5
+export OP_RETH_REPO=https://github.com/paradigmxyz/reth.git
+
+export NETHERMIND_TAG=1.31.11
+export NETHERMIND_COMMIT=2be1890ee4f21f921a471de058dcb57937bd9b90
+export NETHERMIND_REPO=https://github.com/NethermindEth/nethermind.git
+
+export BASE_RETH_NODE_TAG=v0.1.1
+export BASE_RETH_NODE_COMMIT=cb55e69e3d88f8272ccc523c6c352d00b4ce2bf1
+export BASE_RETH_NODE_REPO=https://github.com/base/node-reth.git 
+

--- a/versions.env
+++ b/versions.env
@@ -14,7 +14,7 @@ export NETHERMIND_TAG=1.31.11
 export NETHERMIND_COMMIT=2be1890ee4f21f921a471de058dcb57937bd9b90
 export NETHERMIND_REPO=https://github.com/NethermindEth/nethermind.git
 
-export BASE_RETH_NODE_TAG=v0.1.1
-export BASE_RETH_NODE_COMMIT=cb55e69e3d88f8272ccc523c6c352d00b4ce2bf1
+export BASE_RETH_NODE_TAG=v0.1.2
+export BASE_RETH_NODE_COMMIT=7fe1d4e7c74d322d2cf78df55db40e14f466cfc6
 export BASE_RETH_NODE_REPO=https://github.com/base/node-reth.git 
 


### PR DESCRIPTION
This PR updates the Dockerfiles for the geth, reth, and nethermind folders to pull the versions for their dependencies from a .env folder rather than manually having to set the versions in multiple different places when it's time to update.

This PR is part of a ticket [(CHAIN-1536)](https://linear.app/coinbase/issue/CHAIN-1536/automate-node-upgrade-process) to automate the node upgrade process to make the process more efficient.