### PR TITLE
fix: allow github actions to push packages

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ env:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   geth:


### PR DESCRIPTION
### Description
Allow the Github Action to publish the docker packages for the nodes. This was broken in https://github.com/base/node/pull/481