### PR TITLE
Update Nethermind to 1.32.0

### DIFF
--- a/versions.env
+++ b/versions.env
@@ -1,9 +1,9 @@
 export BASE_RETH_NODE_COMMIT=7fe1d4e7c74d322d2cf78df55db40e14f466cfc6
 export BASE_RETH_NODE_REPO=https://github.com/base/node-reth.git
 export BASE_RETH_NODE_TAG=v0.1.2
-export NETHERMIND_COMMIT=2be1890ee4f21f921a471de058dcb57937bd9b90
+export NETHERMIND_COMMIT=55fe750c2217762c3f4b682ab163e5214a78edfc
 export NETHERMIND_REPO=https://github.com/NethermindEth/nethermind.git
-export NETHERMIND_TAG=1.31.11
+export NETHERMIND_TAG=1.32.0
 export OP_GETH_COMMIT=68075997f33907401a93216aa426514c5ddc8870
 export OP_GETH_REPO=https://github.com/ethereum-optimism/op-geth.git
 export OP_GETH_TAG=v1.101511.0

--- a/versions.json
+++ b/versions.json
@@ -10,8 +10,8 @@
 	  },
 	  "nethermind": {
 	  	  "repoUrl": "https://github.com/NethermindEth/nethermind.git",
-	  	  "tag": "1.31.11",
-	  	  "commit": "2be1890ee4f21f921a471de058dcb57937bd9b90",
+	  	  "tag": "1.32.0",
+	  	  "commit": "55fe750c2217762c3f4b682ab163e5214a78edfc",
 	  	  "commitUrl": "https://api.github.com/repos/NethermindEth/nethermind/commits/",
 	  	  "versionUrl": "https://api.github.com/repos/NethermindEth/nethermind/releases",
 	  	  "Owner": "NethermindEth",


### PR DESCRIPTION
Bumps the listed Nethermind version to 1.32.0. This Nethermind version includes several bugfixes to OP Stack chains like Base.