### PR TITLE
Dependency Updater: Add Step to Remove .env

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -38,3 +38,6 @@ jobs:
           body: ${{ env.DESC }}
           branch: run-dependency-updater
           delete-branch: true
+
+      - name: remove commit message .env
+        run: rm -rf commit_message.env


### PR DESCRIPTION
This PR adds an extra step to the github update dependencies action workflow to remove the commit_message.env after loading it to avoid including it in the pull request.