### PR TITLE
Dependency Updater: remove newline char from commit message

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -134,11 +134,11 @@ func updater(token string, repoPath string, commit bool, githubAction bool) erro
 func createCommitMessage(updatedDependencies []VersionUpdateInfo, repoPath string, githubAction bool) error {
 	var repos []string
 	commitTitle := "chore: updated "
-	commitDescription := "Updated dependencies for: \n"
+	commitDescription := "Updated dependencies for: "
 
 	for _, dependency := range updatedDependencies {
 		repo, tag := dependency.Repo, dependency.To
-		commitDescription += repo + " => " + tag + " (" + dependency.DiffUrl + ")" + "\n"
+		commitDescription += repo + " => " + tag + " (" + dependency.DiffUrl + ") "
 		repos = append(repos, repo)
 	}
 	commitDescription = strings.TrimSuffix(commitDescription, "\n")


### PR DESCRIPTION
This PR removes the newline char from the created commit message to test parsing the commit_message.env through the action manually rather than using an external action to do it.