### PR TITLE
Dependency Updater: change workflow to use GITHUB_OUTPUT instead of env

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,8 +1,8 @@
 name: Update Dockerfile Dependencies
 on:
-  # schedule:
-  #   - cron: '0 13 * * *'
-  pull_request:
+  schedule:
+    - cron: '0 13 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,8 +1,8 @@
 name: Update Dockerfile Dependencies
 on:
-  schedule:
-    - cron: '0 13 * * *'
-  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 13 * * *'
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -29,10 +29,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd dependency_updater && ./dependency_updater --repo ../ --github-action true
 
-      - name: remove commit message .env
-        if: ${{ steps.run_dependency_updater.outputs.TITLE != '' }}
-        run: rm commit_message.env
-
       - name: create pull request
         if: ${{ steps.run_dependency_updater.outputs.TITLE != '' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -19,8 +19,6 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: use-github-output
 
       - name: build dependency updater
         run: cd dependency_updater && go build

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -26,26 +26,21 @@ jobs:
         run: cd dependency_updater && go build
 
       - name: run dependency updater
+        id: run_dependency_updater
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd dependency_updater && ./dependency_updater --repo ../ --github-action true
 
-      - name: load commit message/title .env file
-        if: ${{ hashFiles('commit_message.env') != '' }}
-        uses: aarcangeli/load-dotenv@2afd907c7bb1c0324d22a6192693213867e77443 # v1.1.0
-        with:
-          filenames: 'commit_message.env'
-
       - name: remove commit message .env
-        if: ${{ hashFiles('commit_message.env') != '' }}
+        if: ${{ steps.run_dependency_updater.outputs.TITLE != '' }}
         run: rm commit_message.env
 
       - name: create pull request
-        if: ${{ env.TITLE != '' }}
+        if: ${{ steps.run_dependency_updater.outputs.TITLE != '' }}
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
-          title: ${{ env.TITLE }}
-          commit-message: ${{ env.TITLE }}
-          body: ${{ env.DESC }}
+          title: ${{ steps.run_dependency_updater.outputs.TITLE }}
+          commit-message: ${{ steps.run_dependency_updater.outputs.TITLE }}
+          body: ${{ steps.run_dependency_updater.outputs.DESC }}
           branch: run-dependency-updater
           delete-branch: true

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: main
+          ref: use-github-output
 
       - name: build dependency updater
         run: cd dependency_updater && go build

--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -332,17 +332,18 @@ func createVersionsEnv(repoPath string, dependencies Dependencies) error {
 }
 
 func createGitMessageEnv(title string, description string, repoPath string) error {
-	file, err := os.Create(repoPath + "/commit_message.env")
+	file := os.Getenv("GITHUB_OUTPUT")
+	f, err := os.OpenFile(file, os.O_APPEND, 0644)
 	if err != nil {
-		return fmt.Errorf("error creating commit_message.env file: %s", err)
+		return fmt.Errorf("error failed to open GITHUB_OUTPUT file: %s", err)
 	}
-	defer file.Close()
+	defer f.Close()
 
-	envString := "export TITLE=" + title + "\nexport DESC=" + description
-	_, err = file.WriteString(envString)
+	_, err = f.WriteString("TITLE=" + title + "\n" + "DESC=" + description)
 	if err != nil {
-		return fmt.Errorf("error writing to commit_message.env file: %s", err)
+		return fmt.Errorf("error faile to write to GITHUB_OUTPUT file: %s", err)
 	}
+
 	return nil
 }
 

--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -338,11 +338,13 @@ func createGitMessageEnv(title string, description string, repoPath string) erro
 		return fmt.Errorf("error failed to open GITHUB_OUTPUT file: %s", err)
 	}
 	defer f.Close()
+
 	titleToWrite := fmt.Sprintf("%s=%s\n", "TITLE", title)
 	_, err = f.WriteString(titleToWrite)
 	if err != nil {
 		return fmt.Errorf("error failed to write to GITHUB_OUTPUT file: %s", err)
 	}
+	
 	descToWrite := fmt.Sprintf("%s=%s\n", "DESC", description)
 	_, err = f.WriteString(descToWrite)
 	if err != nil {

--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -343,6 +343,11 @@ func createGitMessageEnv(title string, description string, repoPath string) erro
 	if err != nil {
 		return fmt.Errorf("error failed to write to GITHUB_OUTPUT file: %s", err)
 	}
+	descToWrite := fmt.Sprintf("%s=%s\n", "DESC", description)
+	_, err = f.WriteString(descToWrite)
+	if err != nil {
+		return fmt.Errorf("error failed to write to GITHUB_OUTPUT file: %s", err)
+	}
 
 	return nil
 }

--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -333,15 +333,15 @@ func createVersionsEnv(repoPath string, dependencies Dependencies) error {
 
 func createGitMessageEnv(title string, description string, repoPath string) error {
 	file := os.Getenv("GITHUB_OUTPUT")
-	f, err := os.OpenFile(file, os.O_APPEND, 0644)
+	f, err := os.OpenFile(file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("error failed to open GITHUB_OUTPUT file: %s", err)
 	}
 	defer f.Close()
-
-	_, err = f.WriteString("TITLE=" + title + "\n" + "DESC=" + description)
+	titleToWrite := fmt.Sprintf("%s=%s\n", "TITLE", title)
+	_, err = f.WriteString(titleToWrite)
 	if err != nil {
-		return fmt.Errorf("error faile to write to GITHUB_OUTPUT file: %s", err)
+		return fmt.Errorf("error failed to write to GITHUB_OUTPUT file: %s", err)
 	}
 
 	return nil

--- a/versions.json
+++ b/versions.json
@@ -21,8 +21,8 @@
 	  	  "tracking": "tag"
 	  },
 	  "op_node": {
-	  	  "tag": "op-node/v1.13.5",
-	  	  "commit": "7a0ab04ea2db5421da689eb77a68e674e4ae9cfe",
+	  	  "tag": "op-node/v1.13.4",
+	  	  "commit": "7eedfced77eb30ae72cc8d0e7c793dd2d1b6f161",
 	  	  "tagPrefix": "op-node",
 	  	  "owner": "ethereum-optimism",
 	  	  "repo": "optimism",

--- a/versions.json
+++ b/versions.json
@@ -21,8 +21,8 @@
 	  	  "tracking": "tag"
 	  },
 	  "op_node": {
-	  	  "tag": "op-node/v1.13.4",
-	  	  "commit": "7eedfced77eb30ae72cc8d0e7c793dd2d1b6f161",
+	  	  "tag": "op-node/v1.13.5",
+	  	  "commit": "7a0ab04ea2db5421da689eb77a68e674e4ae9cfe",
 	  	  "tagPrefix": "op-node",
 	  	  "owner": "ethereum-optimism",
 	  	  "repo": "optimism",


### PR DESCRIPTION
This PR updates the github action workflow for the dependency updater to read from the GITHUB_OUTPUT env instead of creating a new env and having to parse it to retrieve the commit title and description. 

This PR also adds a diff string to updated dependencies that track branches to show prev + current commit hash.