### PR TITLE
Dependency updater: remove hardcoded dependency key from debug line

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -292,7 +292,6 @@ func updateVersionTagAndCommit(
 func writeToVersionsJson(repoPath string, dependencies Dependencies) error {
 	// formatting json
 	updatedJson, err := json.MarshalIndent(dependencies, "", "	  ")
-	print(dependencies["base_reth_node"].Branch)
 	if err != nil {
 		return fmt.Errorf("error Marshaling dependencies json: %s", err)
 	}


### PR DESCRIPTION
Removed the problematic debug line `print(dependencies["base_reth_node"].Branch)` 
from the writeToVersionsJson function. This line contained a hardcoded key that 
could cause a panic if the key doesn't exist in the dependencies map. The line 
was not serving any functional purpose and was likely leftover debug code.