### PR TITLE
reth-entrypoint: use safe parameter expansion to prevent set -u unbound variable errors

### DIFF
--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -12,13 +12,13 @@ P2P_PORT="${P2P_PORT:-30303}"
 ADDITIONAL_ARGS=""
 NODE_TYPE="${NODE_TYPE:-vanilla}"
 
-if [[ -z "$RETH_CHAIN" ]]; then
+if [[ -z "${RETH_CHAIN:-}" ]]; then
     echo "expected RETH_CHAIN to be set" 1>&2
     exit 1
 fi
 
 # Add Flashblocks support for base mode
-if [[ "$NODE_TYPE" == "base" && -n "$RETH_FB_WEBSOCKET_URL" ]]; then
+if [[ "$NODE_TYPE" == "base" && -n "${RETH_FB_WEBSOCKET_URL:-}" ]]; then
     ADDITIONAL_ARGS="--websocket-url=$RETH_FB_WEBSOCKET_URL"
     echo "Enabling Flashblocks support with endpoint: $RETH_FB_WEBSOCKET_URL"
 fi


### PR DESCRIPTION
Reason: With set -u, referencing unset variables in conditions (e.g., [[ -z "$RETH_CHAIN" ]] and checking RETH_FB_WEBSOCKET_URL) causes an “unbound variable” error, terminating the script unexpectedly.
Change: Updated conditional checks to use safe expansion ${RETH_CHAIN:-} and ${RETH_FB_WEBSOCKET_URL:-}.
Goal: Prevent crashes when optional env vars are unset while preserving existing behavior when they are provided.