### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,18 +4,20 @@ services:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
     ports:
-      - "8545:8545" # RPC
-      - "8546:8546" # websocket
-      - "7301:6060" # metrics
-      - "30303:30303" # P2P TCP
+      - "8545:8545"   # RPC (should be restricted, not exposed to 0.0.0.0 in production)
+      - "8546:8546"   # WebSocket (same caution as RPC)
+      - "7301:6060"   # Metrics (better to bind only on localhost)
+      - "30303:30303"     # P2P TCP
       - "30303:30303/udp" # P2P UDP
     command: ["bash", "./execution-entrypoint"]
     volumes:
-      - ${HOST_DATA_DIR}:/data
+      - ${HOST_DATA_DIR}:/data:rw
     environment:
       - NODE_TYPE=${NODE_TYPE:-vanilla}
     env_file:
-      - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+      - ${NETWORK_ENV:-.env.mainnet} # Default mainnet, override with .env.sepolia
+    restart: unless-stopped   # Ensures container restarts on failure
+
   node:
     build:
       context: .
@@ -23,11 +25,12 @@ services:
     depends_on:
       - execution
     ports:
-      - "7545:8545" # RPC
-      - "9222:9222" # P2P TCP
-      - "9222:9222/udp" # P2P UDP
-      - "7300:7300" # metrics
-      - "6060:6060" # pprof
+      - "7545:8545"   # RPC (should be restricted in production)
+      - "9222:9222"       # P2P TCP
+      - "9222:9222/udp"   # P2P UDP
+      - "7300:7300"   # Metrics (limit exposure)
+      - "6060:6060"   # pprof (limit exposure)
     command: ["bash", "./op-node-entrypoint"]
     env_file:
-      - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+      - ${NETWORK_ENV:-.env.mainnet}
+    restart: unless-stopped


### PR DESCRIPTION
chore(docker-compose): improve node service security & reliability

- Added `restart: unless-stopped` for automatic recovery
- Clarified volume mount permissions (:rw specified)
- Documented that RPC, WebSocket, metrics, and pprof ports should NOT be publicly exposed
- Kept environment variable fallbacks for flexibility (.env.mainnet / .env.sepolia)