### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,18 +4,26 @@ services:
       context: .
       dockerfile: ${CLIENT:-geth}/Dockerfile
     ports:
-      - "8545:8545" # RPC
-      - "8546:8546" # websocket
-      - "7301:6060" # metrics
-      - "30303:30303" # P2P TCP
+      - "8545:8545"       # RPC (⚠️ restrict to localhost in production)
+      - "8546:8546"       # WebSocket (same caution as RPC)
+      - "7301:6060"       # Metrics (should be internal only)
+      - "30303:30303"     # P2P TCP
       - "30303:30303/udp" # P2P UDP
     command: ["bash", "./execution-entrypoint"]
     volumes:
-      - ${HOST_DATA_DIR}:/data
+      - ${HOST_DATA_DIR}:/data:rw   # explicitly mark as read-write
     environment:
       - NODE_TYPE=${NODE_TYPE:-vanilla}
     env_file:
-      - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+      - ${NETWORK_ENV:-.env.mainnet}
+    restart: unless-stopped         # ensure container auto-restarts on failure
+    healthcheck:                    # basic healthcheck for service monitoring
+      test: ["CMD", "curl", "-f", "http://localhost:8545"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
   node:
     build:
       context: .
@@ -23,11 +31,18 @@ services:
     depends_on:
       - execution
     ports:
-      - "7545:8545" # RPC
-      - "9222:9222" # P2P TCP
-      - "9222:9222/udp" # P2P UDP
-      - "7300:7300" # metrics
-      - "6060:6060" # pprof
+      - "7545:8545"       # RPC (⚠️ restrict to localhost in production)
+      - "9222:9222"       # P2P TCP
+      - "9222:9222/udp"   # P2P UDP
+      - "7300:7300"       # Metrics (should be internal only)
+      - "6060:6060"       # pprof (⚠️ sensitive debugging info)
     command: ["bash", "./op-node-entrypoint"]
     env_file:
-      - ${NETWORK_ENV:-.env.mainnet} # Use .env.mainnet by default, override with .env.sepolia for testnet
+      - ${NETWORK_ENV:-.env.mainnet}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7545"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s


### PR DESCRIPTION
chore(docker-compose): add healthchecks and improve service reliability

- Added restart policy (`unless-stopped`) for both services
- Introduced healthchecks on RPC endpoints for monitoring
- Explicitly marked volume mount as read-write (:rw)
- Added security notes to ports (RPC, WebSocket, metrics, pprof should not be publicly exposed)