### PR TITLE
fix: use branch name as tag for branch-tracked dependencies

### DIFF
--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -270,6 +270,11 @@ func getVersionAndCommit(ctx context.Context, client *github.Client, dependencie
 		return *version.TagName, commit, updatedDependency, nil
 	}
 
+	// For branch tracking, use branch name as tag
+	if dependencies[dependencyType].Tracking == "branch" {
+		return dependencies[dependencyType].Branch, commit, updatedDependency, nil
+	}
+
 	return "", commit, updatedDependency, nil
 }
 

--- a/dependency_updater/dependency_updater.go
+++ b/dependency_updater/dependency_updater.go
@@ -264,15 +264,12 @@ func getVersionAndCommit(ctx context.Context, client *github.Client, dependencie
 				diff,
 			}
 		}
+		// For branch tracking, return branch name as the tag
+		return dependencies[dependencyType].Branch, commit, updatedDependency, nil
 	}
 
 	if version != nil {
 		return *version.TagName, commit, updatedDependency, nil
-	}
-
-	// For branch tracking, use branch name as tag
-	if dependencies[dependencyType].Tracking == "branch" {
-		return dependencies[dependencyType].Branch, commit, updatedDependency, nil
 	}
 
 	return "", commit, updatedDependency, nil


### PR DESCRIPTION
When tracking dependencies by branch instead of tag, the dependency updater was writing empty TAG values to versions.env. Now uses the branch name as the tag value for proper environment variable generation.